### PR TITLE
Isocommonref

### DIFF
--- a/processing/spikesSiliconProbesV2.m
+++ b/processing/spikesSiliconProbesV2.m
@@ -6,7 +6,7 @@ function [channels, artifacts] = spikesSiliconProbesV2(sourceFile, spikesFile)
 channels = 1 : 32;
 
 % Extract the common reference - mean across channels at each timepoint
-extract_common_referenceSP(sourceFile);
+extract_common_referenceSP(sourceFile, 'channels', 1:32);
 
 matlabpool
 

--- a/processing/spikesSiliconProbesV2.m
+++ b/processing/spikesSiliconProbesV2.m
@@ -1,0 +1,20 @@
+function [channels, artifacts] = spikesSiliconProbesV2(sourceFile, spikesFile)
+% Spike detection callback for silicon probes.
+% AE 2011-10-26
+
+
+channels = 1 : 32;
+
+% Extract the common reference - mean across channels at each timepoint
+extract_common_referenceSP(sourceFile);
+
+matlabpool
+
+parfor i = channels
+    fprintf('Extracting spikes from channel %d\n', i);
+    outFile = sprintf(strrep(spikesFile, '\', '\\'), i);
+    detectSpikesSPV2(sourceFile, i, outFile);
+end
+
+matlabpool close
+artifacts = cell(1, numel(channels));

--- a/processing/spikesSiliconProbesV2.m
+++ b/processing/spikesSiliconProbesV2.m
@@ -6,7 +6,7 @@ function [channels, artifacts] = spikesSiliconProbesV2(sourceFile, spikesFile)
 channels = 1 : 32;
 
 % Extract the common reference - mean across channels at each timepoint
-extract_common_reference(sourceFile, 'channels', 1:32);
+extract_common_reference(sourceFile, 'channels', channels);
 
 matlabpool
 

--- a/processing/spikesSiliconProbesV2.m
+++ b/processing/spikesSiliconProbesV2.m
@@ -6,7 +6,7 @@ function [channels, artifacts] = spikesSiliconProbesV2(sourceFile, spikesFile)
 channels = 1 : 32;
 
 % Extract the common reference - mean across channels at each timepoint
-extract_common_referenceSP(sourceFile, 'channels', 1:32);
+extract_common_reference(sourceFile, 'channels', 1:32);
 
 matlabpool
 

--- a/processing/spikesUtah.m
+++ b/processing/spikesUtah.m
@@ -10,7 +10,7 @@ function [electrodes, artifacts] = spikesUtah(sourceFile, spikesFile)
 electrodes = 1:96;
 
 % Extract the common reference
-extract_common_reference(sourceFile, 'channels', 1:96);
+extract_common_reference(sourceFile, 'channels', electrodes);
 
 matlabpool
 

--- a/processing/spikesUtah.m
+++ b/processing/spikesUtah.m
@@ -10,7 +10,7 @@ function [electrodes, artifacts] = spikesUtah(sourceFile, spikesFile)
 electrodes = 1:96;
 
 % Extract the common reference
-extract_common_reference(sourceFile);
+extract_common_reference(sourceFile, 'channels', 1:96);
 
 matlabpool
 

--- a/schemas/+detect/Sets.m
+++ b/schemas/+detect/Sets.m
@@ -40,6 +40,10 @@ classdef Sets < dj.Relvar & dj.AutoPopulate
 %                     muaCb = @extractMuaSiliconProbes;
 %                     pathCb = @extractPath;
                     lfpCb = []; muaCb = []; pathCb = [];
+                case 'SiliconProbesV2'
+                    spikesCb = @spikesSiliconProbesV2;
+                    spikesFile = 'Sc%d.Htt';
+                    lfpCb = []; muaCb = []; pathCb = [];
                 case 'Utah'
                     spikesCb = @spikesUtah;
                     spikesFile = 'Sc%03u.Hsp';


### PR DESCRIPTION
Created spikesSiliconProbesV2 file for common reference subtraction and updated detect schema to handle new spike detection method (SiliconProbesV2) which subtracts common reference before running detection. These changes have been tested on the backup database in conjunction with files from other, simultaneous pull request on common ref branch