### PR TITLE
Basic spike sorting for multi-channel probes

### DIFF
--- a/migration/multiChannelSorting.m
+++ b/migration/multiChannelSorting.m
@@ -1,0 +1,54 @@
+% Migration script for database updates related to spike sorting of
+% multi-channel probes.
+%
+% AE 2015-08-28
+
+%% Create array info tables
+acq.ArrayInfo
+acq.ArrayShanks
+acq.ArrayChannels
+
+
+%% Insert arrays
+insert(acq.ArrayInfo, struct('array_id', 0, 'array_name', 'unknown', 'num_shanks', 0, 'num_channels', 0, 'vendor', 'n/a'))
+
+insert(acq.ArrayInfo, struct('array_id', 1, 'array_name', 'V1x32-Edge-10mm-60-177-V32', 'num_shanks', 1, 'num_channels', 32, 'vendor', 'NeuroNexus', 'contact_area', 177, 'contact_material', 'Iridium'))
+insert(acq.ArrayShanks, struct('array_id', 1, 'shank_num', 1, 'num_channels', 32))
+for i = 1 : 32
+    insert(acq.ArrayChannels, struct('array_id', 1, 'channel_num', i, 'shank_num', 1, 'x_coord', 0, 'y_coord', 60 * (i - 1), 'z_coord', 0))
+end
+
+insert(acq.ArrayInfo, struct('array_id', 2, 'array_name', 'V1x32-Poly2-15mm-50s-177', 'num_shanks', 1, 'num_channels', 32, 'vendor', 'NeuroNexus', 'contact_area', 177, 'contact_material', 'Iridium'))
+insert(acq.ArrayShanks, struct('array_id', 2, 'shank_num', 1, 'num_channels', 32))
+x = [zeros(1, 16), ones(1, 16) * sqrt(3) / 2 * 50];
+y = [150 : 50 : 750, 100, 50, 0, 25, 75, 125, 775 : -50 : 175];
+for i = 1 : 32
+    insert(acq.ArrayChannels, struct('array_id', 2, 'channel_num', i, 'shank_num', 1, 'x_coord', x(i), 'y_coord', y(i), 'z_coord', 0))
+end
+
+insert(acq.ArrayInfo, struct('array_id', 3, 'array_name', 'V1x32-Edge-15mm-100-177', 'num_shanks', 1, 'num_channels', 32, 'vendor', 'NeuroNexus', 'contact_area', 177, 'contact_material', 'Iridium'))
+insert(acq.ArrayShanks, struct('array_id', 3, 'shank_num', 1, 'num_channels', 32))
+for i = 1 : 32
+    insert(acq.ArrayChannels, struct('array_id', 3, 'channel_num', i, 'shank_num', 1, 'x_coord', 0, 'y_coord', 100 * (i - 1), 'z_coord', 0))
+end
+
+
+%% Update acq.EphysTypes table
+addAttribute(acq.EphysTypes, 'array_id : tinyint unsigned # identifier for array', 'AFTER ephys_task')
+
+% Add foreign key. Due to a MySQL bug the following does not work
+% addForeignKey(acq.EphysTypes, acq.ArrayInfo)
+conn = dj.conn;
+conn.query('ALTER TABLE `acq`.`#ephys_types` ADD CONSTRAINT `#ephys_types_ibfk_2` FOREIGN KEY (array_id) REFERENCES `acq`.`array_info` (array_id) ON UPDATE CASCADE ON DELETE RESTRICT')
+
+alterAttribute(acq.EphysTypes, 'detect_method_num', 'default_detect_method_num : tinyint unsigned # default detect method')
+alterAttribute(acq.EphysTypes, 'sort_method_num', 'default_sort_method_num : tinyint unsigned # default spike sorting method')
+
+
+%% Create channel groups
+detect.ChannelGroupParams
+detect.ChannelGroups
+detect.ChannelGroupMembers
+insert(detect.ChannelGroupParams, struct('array_id', 1, 'count', 6, 'stride', 2))
+insert(detect.ChannelGroupParams, struct('array_id', 2, 'count', 6, 'stride', 2))
+populate(detect.ChannelGroups)

--- a/migration/multiChannelSorting.m
+++ b/migration/multiChannelSorting.m
@@ -45,6 +45,16 @@ alterAttribute(acq.EphysTypes, 'detect_method_num', 'default_detect_method_num :
 alterAttribute(acq.EphysTypes, 'sort_method_num', 'default_sort_method_num : tinyint unsigned # default spike sorting method')
 
 
+%% Assign proper array_ids
+[names, ids] = fetchn(acq.ArrayInfo & 'array_id > 0', 'array_name', 'array_id');
+for i = 1 : numel(names)
+    keys = fetch(acq.EphysTypes & struct('ephys_task', names{i}));
+    for k = keys'
+        update(acq.EphysTypes & k, 'array_id', ids(i))
+    end
+end
+
+
 %% Create channel groups
 detect.ChannelGroupParams
 detect.ChannelGroups

--- a/migration/multiChannelSorting.m
+++ b/migration/multiChannelSorting.m
@@ -1,7 +1,9 @@
 % Migration script for database updates related to spike sorting of
-% multi-channel probes.
+% multi-channel probes. Run this scrtipt to update the database tables
+% after updating the code.
 %
-% AE 2015-08-28
+% AE 2015-09-01
+
 
 %% Create array info tables
 acq.ArrayInfo
@@ -34,6 +36,11 @@ end
 
 
 %% Update acq.EphysTypes table
+
+% NOTE: answer 'no' to all prompts asking whether to update the table
+%       declaration! The changes to the table declaratons are part of this
+%       patch.
+
 addAttribute(acq.EphysTypes, 'array_id : tinyint unsigned # identifier for array', 'AFTER ephys_task')
 
 % Add foreign key. Due to a MySQL bug the following does not work

--- a/processing/createDetectSet.m
+++ b/processing/createDetectSet.m
@@ -11,7 +11,7 @@ function detectKey = createDetectSet(ephysKey, detectMethod, useToolchain)
 
 detectKey = ephysKey;
 if nargin < 2 || isempty(detectMethod)
-    detectKey.detect_method_num = fetch1(acq.Ephys(ephysKey) * acq.EphysTypes, 'detect_method_num');
+    detectKey.detect_method_num = fetch1(acq.Ephys(ephysKey) * acq.EphysTypes, 'default_detect_method_num');
 else
     detectKey.detect_method_num = fetch1(detect.Methods(struct('detect_method_name', detectMethod)), 'detect_method_num');
 end

--- a/processing/createSortSet.m
+++ b/processing/createSortSet.m
@@ -10,7 +10,7 @@ function sortKeys = createSortSet(detectKeys, sortMethod)
 
 sortKeys = fetch(detect.Params(detectKeys));
 if nargin < 2 || isempty(sortMethod)
-    sortMethods = num2cell(fetchn(acq.Ephys(detectKeys) * acq.EphysTypes, 'sort_method_num'));
+    sortMethods = num2cell(fetchn(acq.Ephys(detectKeys) * acq.EphysTypes, 'default_sort_method_num'));
     [sortKeys.sort_method_num] = deal(sortMethods{:});
 else
     [sortKeys.sort_method_num] = deal(fetch1(sort.Methods(struct('sort_method_name', sortMethod)), 'sort_method_num'));

--- a/processing/importBlackrockSession.m
+++ b/processing/importBlackrockSession.m
@@ -50,8 +50,8 @@ tuple = key;
 tuple.setup = setup;
 tuple.ephys_task = ephysTask;
 tuple.ephys_type = 'Tetrodes';
-tuple.detect_method_num = fetch1(detect.Methods('detect_method_name = "TetrodesV2"'), 'detect_method_num');
-tuple.sort_method_num = fetch1(sort.Methods('sort_method_name = "MoKsm"'), 'sort_method_num');
+tuple.default_detect_method_num = fetch1(detect.Methods('detect_method_name = "TetrodesV2"'), 'detect_method_num');
+tuple.default_sort_method_num = fetch1(sort.Methods('sort_method_name = "MoKsm"'), 'sort_method_num');
 inserti(acq.EphysTypes, tuple);
 
 % Sessions

--- a/processing/processSet.m
+++ b/processing/processSet.m
@@ -62,7 +62,7 @@ else
 end
 
 if parToolbox
-    matlabpool close force local
+    delete(gcp('nocreate'))
 end
 
 % If we need to process an LFP kick of these jobs now on a thread
@@ -70,7 +70,7 @@ if ~count(cont.Lfp(key)) && ~isempty(lfpCb)
     outDir = fullfilefs(destDir, lfpDir);
     createOrEmpty(outDir)
     if parToolbox
-        scheduler = findResource('scheduler', 'configuration', 'local');
+        scheduler = parcluster;
         if ~isempty(scheduler.Jobs) % cancel jobs that are still running from a crash
             scheduler.Jobs.destroy();
         end

--- a/processing/spikesMultiChannelProbes.m
+++ b/processing/spikesMultiChannelProbes.m
@@ -1,0 +1,26 @@
+function [electrodes, artifacts] = spikesMultiChannelProbes(sourceFile, spikesFile, channels)
+% Spike detection callback for multi-channel probes
+% AE 2015-07-01
+
+n = size(channels, 1);
+artifacts = cell(1, n);
+if exist('parpool', 'file')
+   parpool
+   parfor i = 1 : n
+       artifacts{i} = run(spikesFile, sourceFile, i, channels(i, :));
+   end
+else
+    for i = 1 : n
+        artifacts{i} = run(spikesFile, sourceFile, i, channels(i, :));
+    end
+end
+electrodes = 1 : n;
+
+
+function artifacts = run(spikesFile, sourceFile, electrode, channels)
+
+fprintf('Extracting spikes on channel group %d\n', electrode);
+channels = arrayfun(@(c) sprintf('s1c%d', c), channels, 'uni', false);
+br = baseReader(sourceFile, channels);
+outFile = sprintf(strrep(spikesFile, '\', '\\'), electrode);
+artifacts = detectSpikesTetrodesV2(br, outFile);

--- a/schemas/+acq/ArrayChannels.m
+++ b/schemas/+acq/ArrayChannels.m
@@ -1,0 +1,15 @@
+%{
+acq.ArrayChannels (manual) # Specifications for recording arrays used
+
+-> acq.ArrayInfo
+channel_num             : tinyint unsigned  # channel number
+---
+-> acq.ArrayShanks
+x_coord                 : double            # channel x (lateral) position in microns
+y_coord                 : double            # channel y (depth) position in microns
+z_coord                 : double            # channel z (ant-post) position in microns
+
+%}
+
+classdef ArrayChannels < dj.Relvar
+end

--- a/schemas/+acq/ArrayInfo.m
+++ b/schemas/+acq/ArrayInfo.m
@@ -1,0 +1,38 @@
+%{
+acq.ArrayInfo (manual) # Specifications for recording arrays used
+
+array_id                     : tinyint unsigned       # identifier for array
+---
+array_name                   : varchar(60)            # name of array
+num_shanks                   : int unsigned           # number of shanks on array
+num_channels                 : int unsigned           # number of channels on array
+vendor                       : varchar(30)            # name of product vendor
+contact_area = NULL          : double                 # area in square microns of contact sites on array
+contact_material = NULL      : varchar(30)            # contact site material
+%}
+
+classdef ArrayInfo < dj.Relvar
+    
+    methods
+        function order = channelOrder(self, coord, shank)
+            % Sort channels
+            %   order = layout.channelOrder('x') returns the channel
+            %   indices ordered by their x coordinate (analogous for y).
+            %
+            %   order = layout.channelOrder('yx') orders first by y, then
+            %   by x.
+            
+            assert(all(ismember(coord, 'xy')), 'Input must specify combination of x and y!')
+            if nargin < 3, shank = 1; end
+            [x, y] = fetchn(self * acq.ArrayChannels & struct('shank_num', shank), 'x_coord', 'y_coord');
+            m = max(max(x), max(y));
+            k = 0;
+            nc = numel(coord);
+            for i = 1 : nc
+                k = k + m ^ (nc - i) * eval(coord(i));
+            end
+            [~, order] = sort(k);
+        end
+    end
+    
+end

--- a/schemas/+acq/ArrayShanks.m
+++ b/schemas/+acq/ArrayShanks.m
@@ -1,0 +1,11 @@
+%{
+acq.ArrayShanks (manual) # Specifications for recording arrays used
+
+-> acq.ArrayInfo
+shank_num       : tinyint unsigned      # shank number on array
+---
+num_channels    : tinyint unsigned      # number of channels on shank
+%}
+
+classdef ArrayShanks < dj.Relvar
+end

--- a/schemas/+acq/EphysTypes.m
+++ b/schemas/+acq/EphysTypes.m
@@ -5,6 +5,7 @@ acq.EphysTypes (lookup)       # contains valid configurations of task, setup and
 setup                 : tinyint unsigned   # setup number
 ephys_task            : varchar(63)        # name of the task
 ---
+->acq.ArrayInfo
 ephys_type            : enum("Utah", "Tetrodes", "SiliconProbes") # type of ephys recording
 detect_method_num     : tinyint unsigned   # default detect method
 sort_method_num       : tinyint unsigned   # default spike sorting method

--- a/schemas/+acq/EphysTypes.m
+++ b/schemas/+acq/EphysTypes.m
@@ -7,8 +7,8 @@ ephys_task            : varchar(63)        # name of the task
 ---
 ->acq.ArrayInfo
 ephys_type            : enum("Utah", "Tetrodes", "SiliconProbes") # type of ephys recording
-detect_method_num     : tinyint unsigned   # default detect method
-sort_method_num       : tinyint unsigned   # default spike sorting method
+default_detect_method_num     : tinyint unsigned   # default detect method
+default_sort_method_num       : tinyint unsigned   # default spike sorting method
 %}
 
 classdef EphysTypes < dj.Relvar

--- a/schemas/+detect/ChannelGroupMembers.m
+++ b/schemas/+detect/ChannelGroupMembers.m
@@ -1,0 +1,10 @@
+%{
+detect.ChannelGroupMembers (manual) # Channel group membership table
+
+-> detect.ChannelGroups
+-> acq.ArrayChannels
+---
+%}
+
+classdef ChannelGroupMembers < dj.Relvar
+end

--- a/schemas/+detect/ChannelGroupParams.m
+++ b/schemas/+detect/ChannelGroupParams.m
@@ -1,0 +1,12 @@
+%{
+detect.ChannelGroupParams (manual) # Parameters for grouping channels
+
+-> acq.ArrayInfo
+---
+count   : tinyint unsigned  # number of channels per group
+stride  : tinyint unsigned  # stride for overlapping groups
+---
+%}
+
+classdef ChannelGroupParams < dj.Relvar
+end

--- a/schemas/+detect/ChannelGroups.m
+++ b/schemas/+detect/ChannelGroups.m
@@ -1,0 +1,33 @@
+%{
+detect.ChannelGroups (manual) # Channel groups
+
+-> detect.ChannelGroupParams
+electrode_num   : tinyint unsigned      # group number (called electrode for compatibility)
+---
+%}
+
+classdef ChannelGroups < dj.Relvar & dj.AutoPopulate
+
+    properties (Constant)
+        popRel = detect.ChannelGroupParams;
+    end
+
+    methods (Access = protected)
+        function makeTuples(self, key)
+            [count, stride] = fetch1(detect.ChannelGroupParams & key, 'count', 'stride');
+            channels = channelOrder(acq.ArrayInfo & key, 'y');
+            idx = bsxfun(@plus, 1 : count, (0 : stride : numel(channels) - count)');
+            groups = channels(idx);
+            n = size(groups, 1);
+            for i = 1 : n
+                tuple = key;
+                tuple.electrode_num = i;
+                self.insert(tuple);
+                for c = groups(i, :)
+                    tuple.channel_num = c;
+                    insert(detect.ChannelGroupMembers, tuple)
+                end
+            end
+        end
+    end
+end

--- a/schemas/+detect/Sets.m
+++ b/schemas/+detect/Sets.m
@@ -20,36 +20,38 @@ classdef Sets < dj.Relvar & dj.AutoPopulate
     
     methods (Access=protected)        
         function makeTuples(~, key)
-            switch fetch1(detect.Params(key) * detect.Methods, 'detect_method_name')
+            method = fetch1(detect.Params(key) * detect.Methods, 'detect_method_name');
+            spikesCb = eval(['@spikes' upper(method(1)) method(2 : end)]);
+            spikesFile = 'Sc%d.Htt';
+            lfpCb = []; muaCb = []; pathCb = [];
+            useTemp = true;
+            switch method
                 case 'Tetrodes'
-                    spikesCb = @spikesTetrodes;
-                    spikesFile = 'Sc%d.Htt';
                     lfpCb = @extractLfpTetrodes;
                     muaCb = @extractMuaTetrodes;
                     pathCb = @extractPath;
                 case 'TetrodesV2'
-                    spikesCb = @spikesTetrodesV2;
-                    spikesFile = 'Sc%d.Htt';
                     lfpCb = @extractLfpTetrodes;
                     muaCb = @extractMuaTetrodes;
                     pathCb = @extractPath;
                 case 'SiliconProbes'
-                    spikesCb = @spikesSiliconProbes;
-                    spikesFile = 'Sc%d.Htt';
-%                     lfpCb = @extractLfpSiliconProbes;
-%                     muaCb = @extractMuaSiliconProbes;
-%                     pathCb = @extractPath;
-                    lfpCb = []; muaCb = []; pathCb = [];
+                    % defaults
                 case 'SiliconProbesV2'
-                    spikesCb = @spikesSiliconProbesV2;
-                    spikesFile = 'Sc%d.Htt';
-                    lfpCb = []; muaCb = []; pathCb = [];
+                    % defaults
                 case 'Utah'
-                    spikesCb = @spikesUtah;
                     spikesFile = 'Sc%03u.Hsp';
-                    lfpCb = []; muaCb = []; pathCb = [];
+                case 'MultiChannelProbes'
+                    rel = acq.Ephys * pro(acq.EphysTypes, 'array_id') * detect.ChannelGroupMembers;
+                    [channels, electrodes] = fetchn(rel & key, ...
+                        'channel_num', 'electrode_num', 'ORDER BY electrode_num, channel_num');
+                    assert(~isempty(channels), 'No channels found. Channel groups not populated for this array?')
+                    electrodes = unique(electrodes);
+                    channels = reshape(channels, [], numel(electrodes))';
+                    spikesCb = @(sourceFile, spikesFile) spikesMultiChannelProbes(sourceFile, spikesFile, channels);
+%                     lfpCb = @extractLfpMultiChannelProbes;
+%                     muaCb = @extractMuaMultiChannelProbes;
+%                     pathCb = @extractPath;
             end
-            useTemp = true;
 
             % if not in toolchain mode, don't extract LFP
             if ~fetch1(detect.Params(key), 'use_toolchain')

--- a/schemas/+detect/Sets.m
+++ b/schemas/+detect/Sets.m
@@ -41,9 +41,9 @@ classdef Sets < dj.Relvar & dj.AutoPopulate
                 case 'Utah'
                     spikesFile = 'Sc%03u.Hsp';
                 case 'MultiChannelProbes'
-                    rel = acq.Ephys * acq.EphysTypes * detect.ChannelGroupMembers;
+                    rel = acq.Ephys * acq.EphysTypes * acq.ArrayChannels * detect.ChannelGroupMembers;
                     [channels, electrodes] = fetchn(rel & key, ...
-                        'channel_num', 'electrode_num', 'ORDER BY electrode_num, channel_num');
+                        'channel_num', 'electrode_num', 'ORDER BY electrode_num, y_coord');
                     assert(~isempty(channels), 'No channels found. Channel groups not populated for this array?')
                     electrodes = unique(electrodes);
                     channels = reshape(channels, [], numel(electrodes))';

--- a/schemas/+detect/Sets.m
+++ b/schemas/+detect/Sets.m
@@ -41,7 +41,7 @@ classdef Sets < dj.Relvar & dj.AutoPopulate
                 case 'Utah'
                     spikesFile = 'Sc%03u.Hsp';
                 case 'MultiChannelProbes'
-                    rel = acq.Ephys * pro(acq.EphysTypes, 'array_id') * detect.ChannelGroupMembers;
+                    rel = acq.Ephys * acq.EphysTypes * detect.ChannelGroupMembers;
                     [channels, electrodes] = fetchn(rel & key, ...
                         'channel_num', 'electrode_num', 'ORDER BY electrode_num, channel_num');
                     assert(~isempty(channels), 'No channels found. Channel groups not populated for this array?')

--- a/schemas/+sort/KalmanAutomatic.m
+++ b/schemas/+sort/KalmanAutomatic.m
@@ -50,6 +50,10 @@ classdef KalmanAutomatic < dj.Relvar & dj.AutoPopulate
                     m.params.ClusterCost = 0.002;
                     m.params.Df = 5;
                     m.params.Tolerance = 0.0005;
+                case 'MultiChannelProbes'
+                    m.params.ClusterCost = 0.002;
+                    m.params.Df = 5;
+                    m.params.Tolerance = 0.0005;
                 case 'SiliconProbes'
                     m.params.ClusterCost = 0.0038;
                     m.params.Df = 8;

--- a/schemas/+sort/KalmanFinalize.m
+++ b/schemas/+sort/KalmanFinalize.m
@@ -24,7 +24,7 @@ classdef KalmanFinalize < dj.Relvar & dj.AutoPopulate
             % Cluster spikes
             %
             % JC 2011-10-21
-            close all
+            
             tuple = key;
             
             model = fetch1(sort.KalmanManual & key,'manual_model');

--- a/sortgui/ClusteringHelper.m
+++ b/sortgui/ClusteringHelper.m
@@ -203,7 +203,7 @@ classdef ClusteringHelper
             end
             c = combnk(feat, 2);
             if size(c, 1) > 6
-                c = c(abs(c(:, 1) - c(:, 2)) <=6, :);
+                c = c(abs(c(:, 1) - c(:, 2)) <=3, :);
             end
             N = size(c, 1);
             n = fix(sqrt(N));
@@ -244,6 +244,9 @@ classdef ClusteringHelper
                     axis(ax)
                     set(axHdl(ij), 'box', 'on', 'xtick', [], 'ytick', [])
                     ij = ij + 1;
+                    if ij > N
+                        break
+                    end
                 end
             end
             if nargout > 0, varargout{1} = axHdl; end
@@ -342,7 +345,7 @@ classdef ClusteringHelper
             X = self.Features.data;
             
             if size(X, 2) > 3
-                feat = 1 : 3 : 10;
+                feat = 1 : 3 : size(X, 2);
             else
                 feat = 1 : size(X, 2);
             end

--- a/sortgui/ClusteringHelper.m
+++ b/sortgui/ClusteringHelper.m
@@ -195,12 +195,16 @@ classdef ClusteringHelper
             color = getClusColor(self, params.clusIds);
             
             % select features to plot
-            if size(X, 2) == 12
-                feat = 1 : 3 : 10;      % tetrodes
+            nFeatures = size(X, 2);
+            if nFeatures >= 12
+                feat = 1 : 3 : nFeatures;      % tetrodes
             else
-                feat = 1 : min(size(X, 2), 4);  % single channel data
+                feat = 1 : min(nFeatures, 4);  % single channel data
             end
             c = combnk(feat, 2);
+            if size(c, 1) > 6
+                c = c(abs(c(:, 1) - c(:, 2)) <=6, :);
+            end
             N = size(c, 1);
             n = fix(sqrt(N));
             m = ceil(N / n);


### PR DESCRIPTION
This code implements basic spike sorting (fitting of mixture model) for multi-channel probes (NeuroNexus et al.). 

The key change is a set of tables storing the channel layout of the probes (`acq.Array*`), which is necessary to automatically determine which channels to group together for spike detection and sorting (`detect.ChannelGroup*`).

This patch requires changes to an existing database table (`acq.EphysTypes`), so it is necessary that the following update script is run after pulling the new code: `migration/multiChannelSorting.m`